### PR TITLE
Fix golangci error for master branch

### DIFF
--- a/basic_suite_test.go
+++ b/basic_suite_test.go
@@ -17,10 +17,11 @@
 package integration_k8s_kind_test
 
 import (
-	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/edwarnicke/exechelper"
 	"github.com/sirupsen/logrus"


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

Currently, golangci job is red on master branch https://github.com/networkservicemesh/integration-k8s-kind/runs/935848369. This PR fixes the problem. 