### PR TITLE
fix: automerge job working incorrectly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
           git fetch --depth=1 origin master
       - name: Only allow go.mod and go.sum changes
         run: |
-          find . -type f ! -name 'go.mod' ! -name 'go.sum ! -name `*.yaml` ! -name `*.yml` -exec git diff --exit-code origin/master -- {} +
+          find . -type f ! -name 'go.mod' ! -name 'go.sum' ! -name '*.yaml' ! -name '*.yml' -exec git diff --exit-code origin/master -- {} +
       - name: Automerge nsmbot PR
         uses: ridedott/merge-me-action@master
         with:


### PR DESCRIPTION
Signed-off-by: Denis Tingajkin <denis.tingajkin@xored.com>

## Motivation

Automerge job cannot merge PRs from the nsmbot