### PR TITLE
Update go.mod and go.sum to latest version from networkservicemesh/in…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/networkservicemesh/integration-k8s-kind
 go 1.15
 
 require (
-	github.com/networkservicemesh/integration-tests v0.0.0-20210208042519-f5823dca2d80
+	github.com/networkservicemesh/integration-tests v0.0.0-20210209135802-61896c5e1a97
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/networkservicemesh/gotestmd v0.0.0-20210125072545-44f3bb8aeefb h1:Xp1rW5BX6L91squ8243Y4HnLJJz/rsfaDuS83JEOF14=
 github.com/networkservicemesh/gotestmd v0.0.0-20210125072545-44f3bb8aeefb/go.mod h1:RsxZNZRDhTSkY21gzrJVC4ufT10bfeHRvrRTtypUx+k=
-github.com/networkservicemesh/integration-tests v0.0.0-20210208042519-f5823dca2d80 h1:kRlAWPYQraBihsUAwrjXsqnkSG/FvwwKo/e+W9zmMqg=
-github.com/networkservicemesh/integration-tests v0.0.0-20210208042519-f5823dca2d80/go.mod h1:7PvRkLEYsrs2QbLqOg7pjudoJoSjgjfkNp+uG64p/6A=
+github.com/networkservicemesh/integration-tests v0.0.0-20210209135802-61896c5e1a97 h1:KNvfNy7D/FKN9vGe0zyX5cRnBv+W5delmU+YCx85tQM=
+github.com/networkservicemesh/integration-tests v0.0.0-20210209135802-61896c5e1a97/go.mod h1:7PvRkLEYsrs2QbLqOg7pjudoJoSjgjfkNp+uG64p/6A=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
…tegration-tests@main networkservicemesh/integration-tests#47

networkservicemesh/integration-tests PR link: https://github.com/networkservicemesh/integration-tests/pull/47

networkservicemesh/integration-tests commit message:
commit 100529834f5054061bd40c1b1192f1aa3767bd43
Author: Network Service Mesh Bot <60070799+nsmbot@users.noreply.github.com>
Date:   Mon Feb 8 06:57:28 2021 -0600

    Update from update/networkservicemesh/deployments-k8s

Signed-off-by: NSMBot <nsmbot@networkservicmesh.io>