### PR TITLE
Add features suite to run on ci

### DIFF
--- a/entry_point_test.go
+++ b/entry_point_test.go
@@ -22,8 +22,13 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/networkservicemesh/integration-tests/suites/basic"
+	"github.com/networkservicemesh/integration-tests/suites/features"
 	"github.com/networkservicemesh/integration-tests/suites/memory"
 )
+
+func TestRunFeatureSuite(t *testing.T) {
+	suite.Run(t, new(features.Suite))
+}
 
 func TestRunBasicSuite(t *testing.T) {
 	suite.Run(t, new(basic.Suite))


### PR DESCRIPTION
Signed-off-by: denis-tingajkin <denis.tingajkin@xored.com>


## Description

Previously we've moved features to separate suite from basic suite https://github.com/networkservicemesh/deployments-k8s/pull/506
Now we need to enable this suite on ci.