### PR TITLE
[qfix] Temporary skip heal tests

### DIFF
--- a/entry_point_test.go
+++ b/entry_point_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestRunHealSuite(t *testing.T) {
+	t.Skip("https://github.com/networkservicemesh/deployments-k8s/pull/1789")
 	suite.Run(t, new(heal.Suite))
 }
 


### PR DESCRIPTION
## Description
Temporary skips heal tests to test veth pair. Should be unskipped after https://github.com/networkservicemesh/deployments-k8s/pull/1789 merged.