### PR TITLE
feat: Drop k8s versions 1.17 and 1.18 and add 1.22 on ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,11 +67,10 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - v1.22.2
           - v1.21.1
           - v1.20.7
           - v1.19.11
-          - v1.18.15
-          - v1.17.11
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - v1.22.2
+          - v1.22.1
           - v1.21.1
           - v1.20.7
           - v1.19.11


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation

Since version 1.19 k8s get a few new features such as startupProbe, projected volumes (that are using in https://github.com/networkservicemesh/deployments-k8s/pull/2898)

That also can be used in our examples to make them simpler. 

So this PR just disables 1.17 and 1.18 where these features are not supported and adds testing on 1.22.