### PR TITLE
Increase timeout for interdomain test package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -220,7 +220,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Interdomain tests
         run: |
-          go test -count 1 -timeout 1h -race -v -run Interdomain
+          go test -count 1 -timeout 1h30m -race -v -run Interdomain
         env:
           ARTIFACTS_DIR: interdomain-logs
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/googleapis/gnostic v0.5.1 // indirect
-	github.com/networkservicemesh/integration-tests v0.0.0-20220831100231-423de12a55e2
+	github.com/networkservicemesh/integration-tests v0.0.0-20220904183453-123418ebe392
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc h1:1L/
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
 github.com/networkservicemesh/integration-tests v0.0.0-20220831100231-423de12a55e2 h1:gGpBd6EriOVUykuk0rcGM8qZVlpu+04V0QgndEjscN8=
 github.com/networkservicemesh/integration-tests v0.0.0-20220831100231-423de12a55e2/go.mod h1:FiN76Emti1ZyhWMIG6vg6kXG//0wSCoKokBvp6i8bjM=
+github.com/networkservicemesh/integration-tests v0.0.0-20220904183453-123418ebe392 h1:YP4LdDWTHQtowcegnOxxfMwpQIHgGIwz3MkkM2ymu2U=
+github.com/networkservicemesh/integration-tests v0.0.0-20220904183453-123418ebe392/go.mod h1:FiN76Emti1ZyhWMIG6vg6kXG//0wSCoKokBvp6i8bjM=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
There was a problem with timeout for the test package in this [run](https://github.com/networkservicemesh/integration-k8s-kind/runs/8186399197?check_suite_focus=true). 