### PR TITLE
Manual update of dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/networkservicemesh/integration-k8s-kind
 go 1.18
 
 require (
-	github.com/networkservicemesh/integration-tests v0.0.0-20221116000236-093b41421a12
+	github.com/networkservicemesh/integration-tests v1.6.1
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/networkservicemesh/integration-k8s-kind
 go 1.18
 
 require (
-	github.com/networkservicemesh/integration-tests v1.6.1
+	github.com/networkservicemesh/integration-tests v0.0.0-20221116110129-3ac85b6c05e8
 	github.com/stretchr/testify v1.7.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc h1:1L/OisEFsOyhwaqeJpYmM1nlJ2dBusUMiszPDBlUip0=
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
-github.com/networkservicemesh/integration-tests v0.0.0-20221116000236-093b41421a12 h1:rL6y0/5ZF0OgkGi1oAqfmRrbR0Ajh3obF82x3H8MW5Q=
-github.com/networkservicemesh/integration-tests v0.0.0-20221116000236-093b41421a12/go.mod h1:qkqJgckg5vY5STByxzKhzhDB+TKCAU0qasuwfJ0cG+s=
+github.com/networkservicemesh/integration-tests v1.6.1 h1:7XOECTS/xHAFtaW6mz7wcUB3632xlDIuBruiXNH/w1o=
+github.com/networkservicemesh/integration-tests v1.6.1/go.mod h1:FiN76Emti1ZyhWMIG6vg6kXG//0wSCoKokBvp6i8bjM=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc h1:1L/OisEFsOyhwaqeJpYmM1nlJ2dBusUMiszPDBlUip0=
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
+github.com/networkservicemesh/integration-tests v0.0.0-20221116110129-3ac85b6c05e8 h1:f92QaIdamAZD0SyF7tJ3gw/J5EUl/RWloh7CemeWR4I=
+github.com/networkservicemesh/integration-tests v0.0.0-20221116110129-3ac85b6c05e8/go.mod h1:qkqJgckg5vY5STByxzKhzhDB+TKCAU0qasuwfJ0cG+s=
 github.com/networkservicemesh/integration-tests v1.6.1 h1:7XOECTS/xHAFtaW6mz7wcUB3632xlDIuBruiXNH/w1o=
 github.com/networkservicemesh/integration-tests v1.6.1/go.mod h1:FiN76Emti1ZyhWMIG6vg6kXG//0wSCoKokBvp6i8bjM=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,6 @@ github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc h1:1L/
 github.com/networkservicemesh/gotestmd v0.0.0-20220628095933-eabbdc09e0dc/go.mod h1:8EWnekTRNX+NxBdTFE24WqUoM7SgJHbiafDBrIIdOmQ=
 github.com/networkservicemesh/integration-tests v0.0.0-20221116110129-3ac85b6c05e8 h1:f92QaIdamAZD0SyF7tJ3gw/J5EUl/RWloh7CemeWR4I=
 github.com/networkservicemesh/integration-tests v0.0.0-20221116110129-3ac85b6c05e8/go.mod h1:qkqJgckg5vY5STByxzKhzhDB+TKCAU0qasuwfJ0cG+s=
-github.com/networkservicemesh/integration-tests v1.6.1 h1:7XOECTS/xHAFtaW6mz7wcUB3632xlDIuBruiXNH/w1o=
-github.com/networkservicemesh/integration-tests v1.6.1/go.mod h1:FiN76Emti1ZyhWMIG6vg6kXG//0wSCoKokBvp6i8bjM=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/tests_interdomain/interdomain_test.go
+++ b/tests_interdomain/interdomain_test.go
@@ -23,12 +23,12 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/networkservicemesh/integration-tests/suites/floating_interdomain"
 	"github.com/networkservicemesh/integration-tests/suites/interdomain"
+	"github.com/networkservicemesh/integration-tests/suites/multicluster"
 )
 
-func TestRunFloatingInterdomainSuite(t *testing.T) {
-	suite.Run(t, new(floating_interdomain.Suite))
+func TestRunMulticlusterSuite(t *testing.T) {
+	suite.Run(t, new(multicluster.Suite))
 }
 
 func TestRunBasicInterdomainSuite(t *testing.T) {


### PR DESCRIPTION
We recently renamed `floating_interdomain` suite into `multicluster`. We need to change related references in tests.

https://github.com/networkservicemesh/integration-k8s-kind/pull/745#event-7821876888