### PR TITLE
Fix kubectl wait for calico

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -164,9 +164,17 @@ jobs:
           image: kindest/node:${{ env.KUBERNETES_VERSION }}
           wait: 0s
       - name: Setup external CNI plugin
+        shell: bash {0}
         run: |
           kubectl create -f https://projectcalico.docs.tigera.io/archive/v3.24/manifests/tigera-operator.yaml
-          kubectl wait --for condition=established --timeout=10s crd/installations.operator.tigera.io
+          for i in {1..5}; do
+            kubectl wait --for condition=established --timeout=1s crd/installations.operator.tigera.io
+            result=$?
+            if [ $result -eq 0 ]; then
+              break
+            fi
+            sleep 1s
+          done
           kubectl create -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/82c88a14e5e0e3cc5d7f70c52cdbc01c999d3a42/yaml/calico/installation-default.yaml
           kubectl apply -k ${{ github.workspace }}/src/github.com/${{ github.repository }}/calico
           kubectl rollout status -n calico-vpp-dataplane ds/calico-vpp-node --timeout=5m


### PR DESCRIPTION
Closes: https://github.com/networkservicemesh/integration-k8s-kind/issues/773

To be sure that `installations` CRD is ready