### PR TITLE
Add af_xdp tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,6 +130,51 @@ jobs:
           name: Single IPv6 logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/ipv6-logs
 
+  ### AF_XDP SUITE
+  kind-afxdp:
+    runs-on: ubuntu-latest
+    env:
+      KUBERNETES_VERSION: "v1.25.0"
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.0
+        with:
+          access_token: ${{ github.token }}
+      - uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+          github-token: ${{ github.token }}
+      - name: Set go env
+        run: |
+          echo GOPATH=$GITHUB_WORKSPACE >> $GITHUB_ENV
+          echo GO111MODULE=on >> $GITHUB_ENV
+          echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
+      - uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/src/github.com/${{ github.repository }}
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
+          config: src/github.com/${{ github.repository }}/cluster-config.yaml
+          version: v0.13.0
+          image: kindest/node:${{ env.KUBERNETES_VERSION }}
+      - name: Check kind cluster
+        run: |
+          kubectl version
+          kubectl get pods -A -o wide
+        working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
+      - name: Integration tests
+        run: |
+          go test -count 1 -timeout 1h -race -v ./tests_afxdp
+        env:
+          ARTIFACTS_DIR: afxdp-logs/${{ env.KUBERNETES_VERSION }}
+        working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
+      - name: Upload artifacts
+        if: ${{ success() || failure() || cancelled() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: afxdp logs
+          path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_afxdp/afxdp-logs
+
   ### SINGLE CALICO CLUSTER
   calico-kind:
     runs-on: ubuntu-latest

--- a/tests_afxdp/afxdp_test.go
+++ b/tests_afxdp/afxdp_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2023 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package single
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/networkservicemesh/integration-tests/suites/afxdp"
+)
+
+func TestRunAfxdpSuite(t *testing.T) {
+	suite.Run(t, new(afxdp.Suite))
+}


### PR DESCRIPTION
This PR adds tests that use AF_XDP management interface

Issue: https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/283