### PR TITLE
Run TestSelect_forwarder sequentially

### DIFF
--- a/tests_single/feature_test.go
+++ b/tests_single/feature_test.go
@@ -48,8 +48,8 @@ func (s *calicoFeatureSuite) BeforeTest(suiteName, testName string) {
 
 func TestRunFeatureSuite(t *testing.T) {
 	if *calicoFlag {
-		parallel.Run(t, new(calicoFeatureSuite), "TestScale_from_zero", "TestVl3_dns", "TestVl3_scale_from_zero", "TestNse_composition")
+		parallel.Run(t, new(calicoFeatureSuite), "TestScale_from_zero", "TestVl3_dns", "TestVl3_scale_from_zero", "TestNse_composition", "TestSelect_forwarder")
 	} else {
-		parallel.Run(t, new(features.Suite), "TestScale_from_zero", "TestVl3_dns", "TestVl3_scale_from_zero", "TestNse_composition")
+		parallel.Run(t, new(features.Suite), "TestScale_from_zero", "TestVl3_dns", "TestVl3_scale_from_zero", "TestNse_composition", "TestSelect_forwarder")
 	}
 }


### PR DESCRIPTION
### Motivation
https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/5521878392

`TestSelect_forwarder` adds new forwarders that accidentally can be used by other tests