### PR TITLE
[qfix] Remove `automerge completed` trigger from `update-dependent-repositories-gomod` workflow

### DIFF
--- a/.github/workflows/update-dependent-repositories-gomod.yaml
+++ b/.github/workflows/update-dependent-repositories-gomod.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_run:
-    types:
-      - completed
-    workflows:
-      - 'automerge'
 jobs:
   update-dependent-repositories:
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.actor == 'nsmbot' || github.event_name == 'push' }}


### PR DESCRIPTION
Remove `automerge completed` trigger from `update-dependent-repositories-gomod` workflow so it doesn't run two times