### PR TITLE
Rollback upload-artifact action to v3.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Single logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/${{ matrix.image }}-logs
@@ -128,7 +128,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Single IPv6 logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/ipv6-logs
@@ -173,7 +173,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: afxdp logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_afxdp/afxdp-logs
@@ -255,7 +255,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Calico logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/calico-logs
@@ -300,7 +300,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: heal-ext logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_heal_ext/heal-ext-logs
@@ -359,7 +359,7 @@ jobs:
         run: kind delete clusters $(kind get clusters)
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: Interdomain logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_interdomain/interdomain-logs
@@ -455,7 +455,7 @@ jobs:
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single
       - name: Upload artifacts
         if: ${{ success() || failure() || cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: tanzu-unmanaged logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tanzu-unmanaged


### PR DESCRIPTION
https://github.com/networkservicemesh/integration-k8s-kind/issues/988

This is a known upload-artifact v4 action issue, reported here: https://github.com/actions/upload-artifact/issues/478

Related breaking changes (source: https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes):

> 2. Uploading to the same named Artifact multiple times.
> Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.

Though many users found the old way much more convenient and preferred to rollback to v3 until [the issue](https://github.com/actions/upload-artifact/issues/478) will be fixed or they're forced to upgrade.

For now, I also suggest rolling back to v3 (not deprecated).