### PR TITLE
Exclude vl3 tests from parallel suite in features and ipsec tests

### DIFF
--- a/tests_single/feature_test.go
+++ b/tests_single/feature_test.go
@@ -60,6 +60,8 @@ func TestRunFeatureSuite(t *testing.T) {
 				featuresSuite.TestVl3_dns,
 				featuresSuite.TestVl3_scale_from_zero,
 				featuresSuite.TestVl3_lb,
+				featuresSuite.TestVl3_dual_stack,
+				featuresSuite.TestVl3_ipv6,
 				featuresSuite.TestNse_composition,
 				featuresSuite.TestSelect_forwarder,
 				featuresSuite.TestScaled_registry))

--- a/tests_single/ipsec_test.go
+++ b/tests_single/ipsec_test.go
@@ -25,5 +25,5 @@ import (
 
 func TestRunIpsecSuite(t *testing.T) {
 	ipsecSuite := new(ipsec_mechanism.Suite)
-	parallel.Run(t, new(ipsec_mechanism.Suite), parallel.WithRunningTestsSynchronously(ipsecSuite.TestVl3_basic))
+	parallel.Run(t, ipsecSuite, parallel.WithRunningTestsSynchronously(ipsecSuite.TestVl3_basic))
 }

--- a/tests_single/ipsec_test.go
+++ b/tests_single/ipsec_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 Cisco and/or its affiliates.
+// Copyright (c) 2022-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/tests_single/ipsec_test.go
+++ b/tests_single/ipsec_test.go
@@ -24,5 +24,6 @@ import (
 )
 
 func TestRunIpsecSuite(t *testing.T) {
-	parallel.Run(t, new(ipsec_mechanism.Suite))
+	ipsecSuite := new(ipsec_mechanism.Suite)
+	parallel.Run(t, new(ipsec_mechanism.Suite), parallel.WithRunningTestsSynchronously(ipsecSuite.TestVl3_basic))
 }


### PR DESCRIPTION
## Issue
https://github.com/networkservicemesh/integration-k8s-kind/issues/1007
https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/10317450720/job/28561772085?pr=1026