### PR TITLE
Isolate TestIpam_policies from parallel running

### DIFF
--- a/tests_single/feature_test.go
+++ b/tests_single/feature_test.go
@@ -64,6 +64,7 @@ func TestRunFeatureSuite(t *testing.T) {
 				featuresSuite.TestVl3_ipv6,
 				featuresSuite.TestNse_composition,
 				featuresSuite.TestSelect_forwarder,
-				featuresSuite.TestScaled_registry))
+				featuresSuite.TestScaled_registry,
+				featuresSuite.TestIpam_policies))
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/integration-k8s-kind/pull/1035