### PR TITLE
Make runtime_loglevel_change test run synchrounous

### DIFF
--- a/tests_single/feature_test.go
+++ b/tests_single/feature_test.go
@@ -64,6 +64,8 @@ func TestRunFeatureSuite(t *testing.T) {
 				featuresSuite.TestVl3_ipv6,
 				featuresSuite.TestNse_composition,
 				featuresSuite.TestSelect_forwarder,
-				featuresSuite.TestScaled_registry))
+				featuresSuite.TestScaled_registry,
+				featuresSuite.TestRuntime_loglevel_change,
+			))
 	}
 }


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/12522

I've added the loglevel change test to the withRunningTestsSynchrounously part, because it fiddles with the forwarder deployment, so to not affect tests running in parallel.