### PR TITLE
Fix upload artifact on ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Single logs
+          name: Single-logs-on-${{ matrix.image }}
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/${{ matrix.image }}-logs
 
   ### SINGLE IPv6 CLUSTER
@@ -149,7 +149,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Single IPv6 logs
+          name: Single-IPv6-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/ipv6-logs
 
   ### AF_XDP SUITE
@@ -193,7 +193,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: afxdp logs
+          name: afxdp-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_afxdp/afxdp-logs
 
   ### SINGLE CALICO CLUSTER
@@ -269,7 +269,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Calico logs
+          name: Calico-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/calico-logs
 
   ### HEAL EXTENDED SUITE
@@ -313,7 +313,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: heal-ext logs
+          name: heal-ext-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_heal_ext/heal-ext-logs
 
   ### INTERDOMAIN CLUSTER
@@ -368,7 +368,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Interdomain logs
+          name: Interdomain-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_interdomain/interdomain-logs
 
   ### EXTENDED OVS SUITE
@@ -412,7 +412,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: ovs_extra logs
+          name: ovs_extra-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_ovs_extended/ovs_extra-logs
 
   ### Tanzu mechanism permutation testing
@@ -461,7 +461,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: tanzu-unmanaged logs
+          name: tanzu-unmanaged-logs
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tanzu-unmanaged
       - name: Cleanup resources
         if: ${{ success() || failure() || cancelled() }}


### PR DESCRIPTION
The artifact creation should not fail when more test failure occurs in different kind version.
Now the kind version is included into the artifact name.

Example test of upload-artifact action workflow: https://github.com/actions/upload-artifact/blob/65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08/.github/workflows/test.yml