### PR TITLE
Fix update artifact name to handle images with digest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ success() || failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: Single-logs-on-${{ matrix.image }}
+          name: Single-logs-on-${{ split(matrix.image, '@')[0] }}
           path: ${{ github.workspace }}/src/github.com/${{ github.repository }}/tests_single/${{ matrix.image }}-logs
 
   ### SINGLE IPv6 CLUSTER


### PR DESCRIPTION
Adjusts the artifact name generation to support `matrix.image` values that may include a `@` digest, ensuring consistent behavior regardless of image format.