### PR TITLE
Uplift calico and vpp-dataplane in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -229,7 +229,7 @@ jobs:
       - name: Setup external CNI plugin
         shell: bash {0}
         run: |
-          kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.26.1/manifests/tigera-operator.yaml
+          kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.29.3/manifests/tigera-operator.yaml
           for i in {1..5}; do
             kubectl wait --for condition=established --timeout=1s crd/installations.operator.tigera.io
             result=$?
@@ -238,9 +238,9 @@ jobs:
             fi
             sleep 1s
           done
-          kubectl create -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/ba374a0583d8ab7938d0e46056c148563ee911ec/yaml/calico/installation-default.yaml
+          kubectl create -f https://raw.githubusercontent.com/projectcalico/vpp-dataplane/v3.29.0/yaml/calico/installation-default.yaml
           kubectl apply -k ${{ github.workspace }}/src/github.com/${{ github.repository }}/calico
-          kubectl rollout status -n calico-vpp-dataplane ds/calico-vpp-node --timeout=5m
+          kubectl rollout status -n calico-vpp-dataplane ds/calico-vpp-node --timeout=15m
       - name: Check kind cluster
         run: |
           kubectl version

--- a/calico/kustomization.yaml
+++ b/calico/kustomization.yaml
@@ -3,7 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://raw.githubusercontent.com/projectcalico/vpp-dataplane/ba374a0583d8ab7938d0e46056c148563ee911ec/yaml/generated/calico-vpp-kind.yaml
+  - https://raw.githubusercontent.com/projectcalico/vpp-dataplane/refs/heads/release/v3.29.0/yaml/generated/calico-vpp-kind.yaml
 
 patchesStrategicMerge:
   - patch.yaml

--- a/calico/patch.yaml
+++ b/calico/patch.yaml
@@ -1,30 +1,4 @@
 ---
-# For our purposes it is sufficient to use fewer resources. Using default values can lead to lack of resources.
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: calico-vpp-node
-  namespace: calico-vpp-dataplane
-spec:
-  template:
-    spec:
-      containers:
-        - name: agent
-          image: artgl/calicovpp-agent:ba374a0
-          resources:
-            requests:
-              cpu: 150m
-        - name: vpp
-          image: artgl/calicovpp-vpp:ba374a0
-          resources:
-            requests:
-              memory: 350Mi
-              cpu: 150m
-            limits:
-              memory: 500Mi
-              cpu: 525m
-
----
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Currently calico job fails in setup phase only. 
Usually the integration test fails to pre-fetch the required images. If this step fails the job still successful.
So calico CI tests has no real meaning.