### PR TITLE
Temporarily prevent kind-ovs-extra CI step from failing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -406,6 +406,7 @@ jobs:
           kubectl get pods -A -o wide
         working-directory: ${{ github.workspace }}/src/github.com/${{ github.repository }}
       - name: Integration tests
+        continue-on-error: true
         run: |
           go test -count 1 -timeout 25m -race -v ./tests_ovs_extended -parallel 4
         env:


### PR DESCRIPTION
## Issue

https://github.com/networkservicemesh/integration-k8s-kind/issues/1079

## Description

This PR temporarily adds `continue-on-error: true` to the Integration tests  step of the `kind-ovs-extra` job in the CI workflow to prevent it from causing the entire workflow to fail due to its current faulty behavior.

**Note**: This is a stopgap measure. Once the underlying issue in the suite is resolved, this flag should be removed to restore proper CI failure detection.