### PR TITLE
Make test case skip logic case-insensitive

### DIFF
--- a/tests_interdomain/interdomain_test.go
+++ b/tests_interdomain/interdomain_test.go
@@ -4,6 +4,8 @@
 //
 // Copyright (c) 2024 Pragmagic Inc. and/or its affiliates.
 //
+// Copyright (c) 2025 Nordix and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +58,7 @@ type msmSuite struct {
 }
 
 func (s *msmSuite) BeforeTest(suiteName, testName string) {
-	if strings.ToLower(testName) == "testnsm_istio" {
+	if strings.EqualFold(testName, "testnsm_istio") {
 		s.T().Skip()
 	}
 }

--- a/tests_ovs_extended/feature_ovs_test.go
+++ b/tests_ovs_extended/feature_ovs_test.go
@@ -2,6 +2,8 @@
 //
 // Copyright (c) 2024 Pragmagic Inc. and/or its affiliates.
 //
+// Copyright (c) 2025 Nordix and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +38,7 @@ type kindFeatOvsSuite struct {
 }
 
 func (s *kindFeatOvsSuite) BeforeTest(suiteName, testName string) {
-	if strings.ToLower(testName) == "testwebhook_smartvf" {
+	if strings.EqualFold(testName, "testwebhook_smartvf") {
 		s.T().Skip()
 	}
 }

--- a/tests_single/feature_test.go
+++ b/tests_single/feature_test.go
@@ -2,6 +2,8 @@
 //
 // Copyright (c) 2024 Pragmagic Inc. and/or its affiliates.
 //
+// Copyright (c) 2025 Nordix and/or its affiliates.
+//
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/tests_single/ovs_test.go
+++ b/tests_single/ovs_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 Nordix Foundation.
+// Copyright (c) 2023-2025 Nordix Foundation.
 //
 // SPDX-License-Identifier: Apache-2.0
 //


### PR DESCRIPTION
## Description

This PR updates the integration test runner to convert test case names to lowercase when checking whether a case should be skipped. This ensures that case-insensitive mismatches don't prevent intended skips from occurring.

## Why this is useful

In local testing, test case names may differ in capitalization from those defined in the workflow. This change improves reliability and consistency when executing integration test cases locally.